### PR TITLE
fix(github-action):  build action failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.15
+
       - name: Unit test
         run: make test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.15
+
       - name: Shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           context: .
           file: ./buildscripts/populator/data/data-populator.Dockerfile
-          push: true
+          push: false
           platforms: linux/amd64, linux/arm64
           tags: |
             openebs/data-populator:ci
@@ -163,7 +163,7 @@ jobs:
         with:
           context: .
           file: ./buildscripts/populator/rsync/rsync-populator.Dockerfile
-          push: true
+          push: false
           platforms: linux/amd64, linux/arm64
           tags: |
             openebs/rsync-populator:ci
@@ -191,7 +191,7 @@ jobs:
         with:
           context: .
           file: ./buildscripts/rsync/daemon/Dockerfile
-          push: true
+          push: false
           platforms: linux/amd64, linux/arm64
           tags: |
             openebs/rsync-daemon:ci
@@ -219,7 +219,7 @@ jobs:
         with:
           context: .
           file: ./buildscripts/rsync/client/Dockerfile
-          push: true
+          push: false
           platforms: linux/amd64, linux/arm64
           tags: |
             openebs/rsync-client:ci

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.5
+          go-version: 1.16.15
 
       - name: Format test
         run: make format
@@ -67,6 +67,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.15
 
       - name: Unit test
         run: make test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -74,37 +74,38 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
 
-  bdd-test:
-    needs: ['unit-test']
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        kubernetes: [v1.22.1]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16.5
-
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: v1.16.0
-          kubernetes version: ${{ matrix.kubernetes }}
-          github token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build images locally
-        run: make lvm-driver-image || exit 1;
-
-      - name: bootstrap
-        run: make bootstrap
-
-      - name: Running tests
-        run: ./ci/ci-test.sh
+# TODO Add below bdd-test action once bdd tests are ready
+#  bdd-test:
+#    needs: ['unit-test']
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: true
+#      matrix:
+#        kubernetes: [v1.22.1]
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v2
+#
+#      - name: Set up Go 1.16
+#        uses: actions/setup-go@v2
+#        with:
+#          go-version: 1.16.5
+#
+#      - name: Setup Minikube-Kubernetes
+#        uses: manusa/actions-setup-minikube@v2.3.0
+#        with:
+#          minikube version: v1.16.0
+#          kubernetes version: ${{ matrix.kubernetes }}
+#          github token: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Build images locally
+#        run: make lvm-driver-image || exit 1;
+#
+#      - name: bootstrap
+#        run: make bootstrap
+#
+#      - name: Running tests
+#        run: ./ci/ci-test.sh
 
   data-populator:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -119,46 +119,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Image Org
-        # sets the default IMAGE_ORG to openebs
-        run: |
-          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
-          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
-
-      - name: Set Build Date
-        id: date
-        run: |
-          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
-
-      - name: Set Tag
-        run: |
-          BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH#v}-ci
-          if [ ${BRANCH} = "develop" ]; then
-            CI_TAG="ci"
-          fi
-          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          # add each registry to which the image needs to be pushed here
-          images: |
-            ${{ env.IMAGE_ORG }}/data-populator
-            quay.io/${{ env.IMAGE_ORG }}/data-populator
-            ghcr.io/${{ env.IMAGE_ORG }}/data-populator
-          tag-latest: false
-          tag-custom-only: true
-          tag-custom: |
-            ${{ env.TAG }}
-
-      - name: Print Tag info
-        run: |
-          echo "BRANCH: ${BRANCH}"
-          echo "${{ steps.docker_meta.outputs.tags }}"
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -170,27 +130,7 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push Image
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -198,12 +138,7 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           tags: |
-            ${{ steps.docker_meta.outputs.tags }}
-          build-args: |
-            DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/data-populator
-            DBUILD_SITE_URL=https://openebs.io
-            BRANCH=${{ env.BRANCH }}
+            openebs/data-populator:ci
 
   rsync-populator:
     runs-on: ubuntu-latest
@@ -212,46 +147,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Image Org
-        # sets the default IMAGE_ORG to openebs
-        run: |
-          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
-          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
-
-      - name: Set Build Date
-        id: date
-        run: |
-          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
-
-      - name: Set Tag
-        run: |
-          BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH#v}-ci
-          if [ ${BRANCH} = "develop" ]; then
-            CI_TAG="ci"
-          fi
-          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          # add each registry to which the image needs to be pushed here
-          images: |
-            ${{ env.IMAGE_ORG }}/rsync-populator
-            quay.io/${{ env.IMAGE_ORG }}/rsync-populator
-            ghcr.io/${{ env.IMAGE_ORG }}/rsync-populator
-          tag-latest: false
-          tag-custom-only: true
-          tag-custom: |
-            ${{ env.TAG }}
-
-      - name: Print Tag info
-        run: |
-          echo "BRANCH: ${BRANCH}"
-          echo "${{ steps.docker_meta.outputs.tags }}"
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -263,27 +158,7 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push Image
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -291,12 +166,7 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           tags: |
-            ${{ steps.docker_meta.outputs.tags }}
-          build-args: |
-            DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/data-populator
-            DBUILD_SITE_URL=https://openebs.io
-            BRANCH=${{ env.BRANCH }}
+            openebs/rsync-populator:ci
 
   rsync-daemon:
     runs-on: ubuntu-latest
@@ -305,46 +175,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Image Org
-        # sets the default IMAGE_ORG to openebs
-        run: |
-          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
-          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
-
-      - name: Set Build Date
-        id: date
-        run: |
-          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
-
-      - name: Set Tag
-        run: |
-          BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH#v}-ci
-          if [ ${BRANCH} = "develop" ]; then
-            CI_TAG="ci"
-          fi
-          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          # add each registry to which the image needs to be pushed here
-          images: |
-            ${{ env.IMAGE_ORG }}/rsync-daemon
-            quay.io/${{ env.IMAGE_ORG }}/rsync-daemon
-            ghcr.io/${{ env.IMAGE_ORG }}/rsync-daemon
-          tag-latest: false
-          tag-custom-only: true
-          tag-custom: |
-            ${{ env.TAG }}
-
-      - name: Print Tag info
-        run: |
-          echo "BRANCH: ${BRANCH}"
-          echo "${{ steps.docker_meta.outputs.tags }}"
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -356,27 +186,7 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push Image
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -384,12 +194,7 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           tags: |
-            ${{ steps.docker_meta.outputs.tags }}
-          build-args: |
-            DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/data-populator
-            DBUILD_SITE_URL=https://openebs.io
-            BRANCH=${{ env.BRANCH }}
+            openebs/rsync-daemon:ci
 
   rsync-client:
     runs-on: ubuntu-latest
@@ -398,46 +203,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Image Org
-        # sets the default IMAGE_ORG to openebs
-        run: |
-          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
-          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
-
-      - name: Set Build Date
-        id: date
-        run: |
-          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
-
-      - name: Set Tag
-        run: |
-          BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH#v}-ci
-          if [ ${BRANCH} = "develop" ]; then
-            CI_TAG="ci"
-          fi
-          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          # add each registry to which the image needs to be pushed here
-          images: |
-            ${{ env.IMAGE_ORG }}/rsync-client
-            quay.io/${{ env.IMAGE_ORG }}/rsync-client
-            ghcr.io/${{ env.IMAGE_ORG }}/rsync-client
-          tag-latest: false
-          tag-custom-only: true
-          tag-custom: |
-            ${{ env.TAG }}
-
-      - name: Print Tag info
-        run: |
-          echo "BRANCH: ${BRANCH}"
-          echo "${{ steps.docker_meta.outputs.tags }}"
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
@@ -449,27 +214,7 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
-      - name: Login to GHCR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & Push Image
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -477,9 +222,4 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           tags: |
-            ${{ steps.docker_meta.outputs.tags }}
-          build-args: |
-            DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/data-populator
-            DBUILD_SITE_URL=https://openebs.io
-            BRANCH=${{ env.BRANCH }}
+            openebs/rsync-client:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.15
+
       - name: Set Image Org
         # sets the default IMAGE_ORG to openebs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16.15
-
       - name: Set Image Org
         # sets the default IMAGE_ORG to openebs
         run: |

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,15 @@ test: format
 vendor: go.mod go.sum deps
 	@go mod vendor
 
+# Bootstrap downloads tools required
+# during build
+.PHONY: bootstrap
+bootstrap: controller-gen install-golangci-lint
+	@for tool in  $(EXTERNAL_TOOLS) ; do \
+		echo "+ Installing $$tool" ; \
+		cd && GO111MODULE=on go get $$tool; \
+	done
+
 manifests:
 	@echo "--------------------------------"
 	@echo "+ Generating data populator crds"

--- a/apis/openebs.io/v1alpha1/doc.go
+++ b/apis/openebs.io/v1alpha1/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // +k8s:deepcopy-gen=package
 // +groupName=openebs.io
 

--- a/apis/openebs.io/v1alpha1/register.go
+++ b/apis/openebs.io/v1alpha1/register.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/apis/openebs.io/v1alpha1/types.go
+++ b/apis/openebs.io/v1alpha1/types.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2022 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // +kubebuilder:object:generate=true
 package v1alpha1
 
@@ -13,10 +29,10 @@ const (
 	StatusFailed             = "Failed"
 )
 
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // RsyncPopulator is a volume populator that helps
 // to create a volume from any rsync source.
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type RsyncPopulator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -24,8 +40,8 @@ type RsyncPopulator struct {
 	Spec RsyncPopulatorSpec `json:"spec"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // RsyncPopulatorList is a list of RsyncPopulator objects
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type RsyncPopulatorList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -46,10 +62,10 @@ type RsyncPopulatorSpec struct {
 	URL string `json:"url"`
 }
 
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // DataPopulator contains information used for populating volume from
 // a given to a desired destination
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type DataPopulator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -76,8 +92,8 @@ type DataPopulatorStatus struct {
 	Message string `json:"message"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // DataPopulatorList is a list of DataPopulator objects
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type DataPopulatorList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/app/populator/data/controller/constant.go
+++ b/app/populator/data/controller/constant.go
@@ -41,8 +41,7 @@ const (
 
 	populatorFinalizer = "openebs.io/populate-target-protection"
 
-	RsyncNamePrefix  = "rsync-daemon-"
-	rsyncServerImage = "abhishek09dh/rsync-daemon:v0.1"
-	rsyncUsername    = "openebs-user"
-	rsyncPassword    = "openebs-pass"
+	RsyncNamePrefix = "rsync-daemon-"
+	rsyncUsername   = "openebs-user"
+	rsyncPassword   = "openebs-pass"
 )

--- a/app/populator/data/controller/controller.go
+++ b/app/populator/data/controller/controller.go
@@ -43,7 +43,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	internalv1alpha1 "github.com/Ab-hishek/data-populator/apis/openebs.io/v1alpha1"
+	internalv1alpha1 "github.com/openebs/data-populator/apis/openebs.io/v1alpha1"
 )
 
 var (

--- a/app/populator/data/controller/template.go
+++ b/app/populator/data/controller/template.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	internalv1alpha1 "github.com/Ab-hishek/data-populator/apis/openebs.io/v1alpha1"
+	internalv1alpha1 "github.com/openebs/data-populator/apis/openebs.io/v1alpha1"
 )
 
 type templateConfig struct {

--- a/app/populator/data/controller/template.go
+++ b/app/populator/data/controller/template.go
@@ -23,6 +23,10 @@ import (
 	internalv1alpha1 "github.com/openebs/data-populator/apis/openebs.io/v1alpha1"
 )
 
+var (
+	RsyncServerImage string
+)
+
 type templateConfig struct {
 	sourcePVCName      string
 	sourcePVCNamespace string
@@ -37,7 +41,7 @@ func templateFromDataPopulator(cr internalv1alpha1.DataPopulator) (*templateConf
 		sourcePVCName:      cr.Spec.SourcePVC,
 		sourcePVCNamespace: cr.Spec.SourcePVCNamespace,
 		destinationPVCSpec: cr.Spec.DestinationPVC,
-		imageName:          rsyncServerImage,
+		imageName:          RsyncServerImage,
 		rsyncUsername:      rsyncUsername,
 		rsyncPassword:      rsyncPassword,
 	}

--- a/app/populator/data/main.go
+++ b/app/populator/data/main.go
@@ -30,6 +30,9 @@ import (
 
 func main() {
 	klog.InitFlags(nil)
+
+	flag.StringVar(&controller.RsyncServerImage, "image-name", "", "Rsync server image to use as data source")
+
 	var kubeconfig *string
 	if home := homedir.HomeDir(); home != "" {
 		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"),

--- a/app/populator/data/main.go
+++ b/app/populator/data/main.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog/v2"
 
-	"github.com/Ab-hishek/data-populator/app/populator/data/controller"
+	"github.com/openebs/data-populator/app/populator/data/controller"
 )
 
 func main() {

--- a/app/populator/rsync/main.go
+++ b/app/populator/rsync/main.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"
 
-	internalv1alpha1 "github.com/Ab-hishek/data-populator/apis/openebs.io/v1alpha1"
+	internalv1alpha1 "github.com/openebs/data-populator/apis/openebs.io/v1alpha1"
 )
 
 const (

--- a/buildscripts/populator/data/Dockerfile
+++ b/buildscripts/populator/data/Dockerfile
@@ -15,7 +15,7 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4173-r0
+RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/populator/data/data-populator.Dockerfile
+++ b/buildscripts/populator/data/data-populator.Dockerfile
@@ -45,7 +45,7 @@ RUN make data-populator
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4173-r0
+RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/populator/rsync/Dockerfile
+++ b/buildscripts/populator/rsync/Dockerfile
@@ -15,7 +15,7 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4173-r0
+RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/populator/rsync/rsync-populator.Dockerfile
+++ b/buildscripts/populator/rsync/rsync-populator.Dockerfile
@@ -45,7 +45,7 @@ RUN make rsync-populator
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4173-r0
+RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/rsync/client/Dockerfile
+++ b/buildscripts/rsync/client/Dockerfile
@@ -15,7 +15,7 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4173-r0
+RUN apk add --no-cache vim=8.2.4619-r0
 RUN apk add --no-cache rsync==3.1.3-r3
 
 ARG DBUILD_DATE

--- a/buildscripts/rsync/daemon/Dockerfile
+++ b/buildscripts/rsync/daemon/Dockerfile
@@ -15,7 +15,7 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4173-r0
+RUN apk add --no-cache vim=8.2.4619-r0
 RUN apk add --no-cache rsync==3.1.3-r3
 
 ARG DBUILD_DATE

--- a/buildscripts/rsync/daemon/entrypoint.sh
+++ b/buildscripts/rsync/daemon/entrypoint.sh
@@ -17,8 +17,8 @@ set -e
 
 # Use the environment variables for rsync username and password.
 # If not provided, the default values will be used
-RSYNC_USERNAME=${RSYNC_USERNAME:-user}
-RSYNC_PASSWORD=${RSYNC_PASSWORD:-pass}
+RSYNC_USERNAME=${RSYNC_USERNAME:-openebs-user}
+RSYNC_PASSWORD=${RSYNC_PASSWORD:-openebs-pass}
 echo "$RSYNC_USERNAME:$RSYNC_PASSWORD" >  /etc/rsyncd.secrets
 chmod 600 /etc/rsyncd.secrets
 

--- a/deploy/data-populator-operator.yaml
+++ b/deploy/data-populator-operator.yaml
@@ -352,12 +352,13 @@ spec:
       serviceAccount: data-populator
       containers:
         - name: data-populator
-          image: abhishek09dh/data-populator:v0.1
+          image: openebs/data-populator:ci
           imagePullPolicy: Always
           command:
             - data-populator
           args:
             - --v=2
+            - --image-name=openebs/rsync-daemon:ci
 
 ---
 
@@ -444,13 +445,13 @@ spec:
       serviceAccount: rsync-populator
       containers:
         - name: rsync-populator
-          image: abhishek09dh/rsync-populator:v0.1
+          image: openebs/rsync-populator:ci
           imagePullPolicy: Always
           command:
             - rsync-populator
           args:
             - --v=2
-            - --image-name=abhishek09dh/rsync-client:v0.1
+            - --image-name=openebs/rsync-client:ci
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/yamls/data-populator.yaml
+++ b/deploy/yamls/data-populator.yaml
@@ -91,9 +91,10 @@ spec:
       serviceAccount: data-populator
       containers:
         - name: data-populator
-          image: abhishek09dh/data-populator:v0.1
+          image: openebs/data-populator:ci
           imagePullPolicy: Always
           command:
             - data-populator
           args:
             - --v=2
+            - --image-name=openebs/rsync-daemon:ci

--- a/deploy/yamls/rsync-populator.yaml
+++ b/deploy/yamls/rsync-populator.yaml
@@ -84,13 +84,13 @@ spec:
       serviceAccount: rsync-populator
       containers:
         - name: rsync-populator
-          image: abhishek09dh/rsync-populator:v0.1
+          image: openebs/rsync-populator:ci
           imagePullPolicy: Always
           command:
             - rsync-populator
           args:
             - --v=2
-            - --image-name=abhishek09dh/rsync-client:v0.1
+            - --image-name=openebs/rsync-client:ci
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/yamls/sample-rsync-daemon.yaml
+++ b/deploy/yamls/sample-rsync-daemon.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: rsync-daemon
-      image: abhishek09dh/rsync-daemon:v0.1
+      image: openebs/rsync-daemon:ci
       env:
         - name: RSYNC_USERNAME
           value: user

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Ab-hishek/data-populator
+module github.com/openebs/data-populator
 
 go 1.16
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR fixes the build action failing issue.

**What this PR does?**:
Build gitHub action were failing because specific go packages are available only in `go1.16` version and by default `ubuntu-latest` image used in the action uses `go1.15.15` version. Hence, some packages were not found.

The fixes that this PR introduces are:
1. Add go-setup action in the build, pull_request and release gitHub actions workflows.
2. It also removes all the references to `Ab-hishek`'s gtihub data-populator code.
3. Add missing license headers in the v1alpha1 packages files.
4. Add missing makefile targets.
5. Updates the go mod module name.
6. update default credentials used in the rsync-daemon image.
7. Change all image names to `openebs` registries.
8. Makes `rsync-daemon` image name configurable in data-populator.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
