### PR TITLE
fix(gitHub-action): remove quay images from build and release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/data-populator
-            quay.io/${{ env.IMAGE_ORG }}/data-populator
             ghcr.io/${{ env.IMAGE_ORG }}/data-populator
           tag-latest: false
           tag-custom-only: true
@@ -172,13 +171,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1
@@ -237,7 +229,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/rsync-populator
-            quay.io/${{ env.IMAGE_ORG }}/rsync-populator
             ghcr.io/${{ env.IMAGE_ORG }}/rsync-populator
           tag-latest: false
           tag-custom-only: true
@@ -265,13 +256,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1
@@ -359,13 +343,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
-
       - name: Login to GHCR
         uses: docker/login-action@v1
         with:
@@ -423,7 +400,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/rsync-client
-            quay.io/${{ env.IMAGE_ORG }}/rsync-client
             ghcr.io/${{ env.IMAGE_ORG }}/rsync-client
           tag-latest: false
           tag-custom-only: true
@@ -451,13 +427,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/data-populator
-            quay.io/${{ env.IMAGE_ORG }}/data-populator
             ghcr.io/${{ env.IMAGE_ORG }}/data-populator
           tag-latest: false
           tag-semver: |
@@ -77,13 +76,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1
@@ -138,7 +130,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/rsync-populator
-            quay.io/${{ env.IMAGE_ORG }}/rsync-populator
             ghcr.io/${{ env.IMAGE_ORG }}/rsync-populator
           tag-latest: false
           tag-semver: |
@@ -165,13 +156,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1
@@ -226,7 +210,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/rsync-daemon
-            quay.io/${{ env.IMAGE_ORG }}/rsync-daemon
             ghcr.io/${{ env.IMAGE_ORG }}/rsync-daemon
           tag-latest: false
           tag-semver: |
@@ -253,13 +236,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1
@@ -314,7 +290,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/rsync-client
-            quay.io/${{ env.IMAGE_ORG }}/rsync-client
             ghcr.io/${{ env.IMAGE_ORG }}/rsync-client
           tag-latest: false
           tag-semver: |
@@ -341,13 +316,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Login to GHCR
         uses: docker/login-action@v1

--- a/buildscripts/populator/data/Dockerfile
+++ b/buildscripts/populator/data/Dockerfile
@@ -15,7 +15,6 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/populator/data/data-populator.Dockerfile
+++ b/buildscripts/populator/data/data-populator.Dockerfile
@@ -45,7 +45,6 @@ RUN make data-populator
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/populator/rsync/Dockerfile
+++ b/buildscripts/populator/rsync/Dockerfile
@@ -15,7 +15,6 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/populator/rsync/rsync-populator.Dockerfile
+++ b/buildscripts/populator/rsync/rsync-populator.Dockerfile
@@ -45,7 +45,6 @@ RUN make rsync-populator
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4619-r0
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/buildscripts/rsync/client/Dockerfile
+++ b/buildscripts/rsync/client/Dockerfile
@@ -15,7 +15,6 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4619-r0
 RUN apk add --no-cache rsync==3.1.3-r3
 
 ARG DBUILD_DATE

--- a/buildscripts/rsync/daemon/Dockerfile
+++ b/buildscripts/rsync/daemon/Dockerfile
@@ -15,7 +15,6 @@
 FROM alpine:3.12
 
 RUN apk add --no-cache bash
-RUN apk add --no-cache vim=8.2.4619-r0
 RUN apk add --no-cache rsync==3.1.3-r3
 
 ARG DBUILD_DATE


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
This PR removes the building and pushing of `quay.io` images in the build and release actions. Since, `quay.io` repo is not setup for data-populator, will be adding this after that is done. 

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: