### PR TITLE
fix(rsync-daemon): remove stale quay entry from rsync-daemon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,6 @@ jobs:
           # add each registry to which the image needs to be pushed here
           images: |
             ${{ env.IMAGE_ORG }}/rsync-daemon
-            quay.io/${{ env.IMAGE_ORG }}/rsync-daemon
             ghcr.io/${{ env.IMAGE_ORG }}/rsync-daemon
           tag-latest: false
           tag-custom-only: true


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

**What this PR does?**:
Build action failed from rsync-daemon due to stale entry in the `build & push` action rsync-daemon. Removing that will resolve the issue.
 
**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: